### PR TITLE
feat: add icons to types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "sanity-plugin-commerce",
+  "name": "@commercelayer/sanity-plugin-commerce",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sanity-plugin-commerce",
+      "name": "@commercelayer/sanity-plugin-commerce",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@sanity/incompatible-plugin": "^1.0.4"
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "react-icons": "^5.0.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^18.4.4",
@@ -17544,6 +17545,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@sanity/incompatible-plugin": "^1.0.4"
+    "@sanity/incompatible-plugin": "^1.0.4",
+    "react-icons": "^5.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.4",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,3 +1,8 @@
+import { BiCheckboxSquare } from 'react-icons/bi';
+import { ImUngroup } from 'react-icons/im';
+import { SlGlobeAlt } from 'react-icons/sl';
+import { TfiShoppingCartFull } from 'react-icons/tfi';
+import { VscTypeHierarchySub } from 'react-icons/vsc';
 import { defineType, FieldDefinition } from 'sanity';
 
 export type Config = {
@@ -30,13 +35,14 @@ const getSchema = ({
   taxonLabel = 'Taxon',
   productAttributes = [],
   variantAttributes = [],
-}: Config): any[] => {
+}: Config): unknown[] => {
   const catalog = defineType({
     name: 'catalog',
     title: 'Catalog',
     description:
       'Represents a collection of products, typically grouped under specific taxonomies for organizational purposes. A catalog is used to present a curated selection of products, often tailored for specific markets, seasons, or themes. It references taxonomies to leverage the established hierarchical structure for product categorization.',
     type: 'document',
+    icon: SlGlobeAlt,
     fields: [
       {
         name: 'name',
@@ -71,6 +77,7 @@ const getSchema = ({
     description:
       'Represents the overall categorization system used to organize products. A taxonomy is a hierarchical structure comprising various taxons. This content type defines the broad categories and their relationships, serving as a framework for the classification of products.',
     type: 'document',
+    icon: ImUngroup,
     fields: [
       {
         name: 'name',
@@ -105,6 +112,7 @@ const getSchema = ({
     description:
       'Represents individual categories or subcategories within a taxonomy. Taxons help in organizing products into hierarchical structures, making it easier to navigate and find products. A taxon can reference other taxons, allowing for nested categorization, and can also link to specific products that fall under it.',
     type: 'document',
+    icon: BiCheckboxSquare,
     fields: [
       {
         name: 'name',
@@ -145,6 +153,7 @@ const getSchema = ({
     description:
       'Represents a general product offering that can have multiple variants. This content type includes basic product information such as the product name and description. It also references the various variants of the product, allowing for a comprehensive view of all available options.',
     type: 'document',
+    icon: TfiShoppingCartFull,
     fields: getAttributes(
       {
         name: {
@@ -182,6 +191,7 @@ const getSchema = ({
     description:
       'Represents a specific variant of a product. Variants are typically different versions of a product, differentiated by attributes like size, color, or other specifications. Each variant has a unique SKU for inventory tracking and may have its own set of images.',
     type: 'document',
+    icon: VscTypeHierarchySub,
     fields: getAttributes(
       {
         name: {


### PR DESCRIPTION
## What I did

Add icons to document types

## How to test

Run a sanity project using `link-watch` on this repo and `npx yalc add @commercelayer/sanity-plugin-commerce && npx yalc link @commercelayer/sanity-plugin-commerce && npm install` on the sanity project.

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
